### PR TITLE
Accept a custom validation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ class User < ApplicationRecord
 end
 ```
 
+You can custom the validation error message with:
+
+```ruby
+class User < ApplicationRecord
+  validates :street, message: 'Looks like this address is not valid!'
+end
+```
+
 Empty addresses are not verified. To require an address, add your own validation.
 
 ```ruby

--- a/lib/mainstreet/address_verifier.rb
+++ b/lib/mainstreet/address_verifier.rb
@@ -1,8 +1,9 @@
 module MainStreet
   class AddressVerifier
-    def initialize(address, country: nil)
+    def initialize(address, country: nil, message: nil)
       @address = address
       @country = country
+      @message = message
     end
 
     def success?
@@ -11,7 +12,7 @@ module MainStreet
 
     def failure_message
       if !result
-        "Address can't be confirmed"
+        @message || "Address can't be confirmed"
       elsif result.respond_to?(:analysis)
         analysis = result.analysis
 
@@ -20,7 +21,7 @@ module MainStreet
           when "Verified"
             nil # success!!
           when "Ambiguous", "Partial", "None"
-            "Address can't be confirmed"
+            @message || "Address can't be confirmed"
           else
             raise "Unknown verification_status"
           end
@@ -29,7 +30,7 @@ module MainStreet
           when "Y"
             nil # success!!
           when "N"
-            "Address can't be confirmed"
+            @message || "Address can't be confirmed"
           when "S"
             "Apartment or suite can't be confirmed"
           when "D"

--- a/lib/mainstreet/model.rb
+++ b/lib/mainstreet/model.rb
@@ -1,6 +1,6 @@
 module MainStreet
   module Model
-    def validates_address(fields:, geocode: false, country: nil)
+    def validates_address(fields:, geocode: false, country: nil, message: nil)
       fields = Array(fields.map(&:to_s))
       geocode_options = {latitude: :latitude, longitude: :longitude}
       geocode_options = geocode_options.merge(geocode) if geocode.is_a?(Hash)
@@ -14,7 +14,7 @@ module MainStreet
           if address.present?
             # must use a different variable than country
             record_country = instance_exec(&country) if country.respond_to?(:call)
-            verifier = MainStreet::AddressVerifier.new(address, country: record_country)
+            verifier = MainStreet::AddressVerifier.new(address, country: record_country, message: message)
             if verifier.success?
               if geocode
                 self.send("#{geocode_options[:latitude]}=", verifier.latitude)


### PR DESCRIPTION
So now you can do:

```ruby
class User < ApplicationRecord
  validates :street, message: 'Looks like this address is not valid!'
end
```