### PR TITLE
fix: Use Geocoder settings to check lookup instead of ENV

### DIFF
--- a/lib/mainstreet/address_verifier.rb
+++ b/lib/mainstreet/address_verifier.rb
@@ -70,7 +70,7 @@ module MainStreet
     end
 
     def lookup
-      ENV["SMARTY_STREETS_AUTH_ID"] ? :smarty_streets : nil
+      Geocoder.config_for_lookup(:smarty_streets).fetch(:api_key) ? :smarty_streets : nil
     end
 
     def message(key, default)


### PR DESCRIPTION
Hey @ankane! 👋🏻 Thanks for mainstreet!

Our third party API environment keys follow a specific pattern that does not match what `mainstreet` is looking for. 

You suggested in #11 to override the Geocoder config from `mainstreet.rb`, but that doesn't work because  `MainStreet::AddressVerifier#lookup` references the environment variables instead of the Geocoder setting:

https://github.com/ankane/mainstreet/blob/b9bd7b0c9d4feeef80b891bdc2ea002ccb914fc9/lib/mainstreet/address_verifier.rb#L72-L74

I replaced this `ENV` check with equivalent code from Geocoder that checks the config to see if the API keys have been set for SmartyStreets. You can see this behavior here:

```
> Geocoder.config_for_lookup(:anything)
=> {
 ...,
 :api_key=>nil,
}

> Geocoder.config_for_lookup(:smarty_streets)
=> {
 ...,
 :api_key=>["auth_id_oasidjflij", "auth_token_laisdjfliajsd"], 
}
```

Then we can manually set the Geocoder settings like you suggested. 

--- 

By the way, the tests currently pass if no `ENV['SMARTY_STREETS_AUTH_ID']` is set, even without VCR's cassettes. I'm not sure if this is intentional.