### PR TITLE
fix: Prevent repeat search calls when result is nil

### DIFF
--- a/lib/mainstreet/address_verifier.rb
+++ b/lib/mainstreet/address_verifier.rb
@@ -4,6 +4,7 @@ module MainStreet
       @address = address
       @country = country
       @locale = locale
+      @searched = false
     end
 
     def success?
@@ -43,13 +44,16 @@ module MainStreet
     end
 
     def result
-      @result ||= begin
+      return @result if @searched
+
+      @result = begin
         options = {lookup: lookup}
         options[:country] = @country if @country && !usa?
         # don't use smarty streets zipcode only API
         # keep mirrored with geocoder gem, including \Z
         # \Z is the same as \z when strip is used
         if @address.to_s.strip !~ /\A\d{5}(-\d{4})?\Z/
+          @searched = true
           Geocoder.search(@address, options).first
         end
       end

--- a/lib/mainstreet/address_verifier.rb
+++ b/lib/mainstreet/address_verifier.rb
@@ -4,7 +4,6 @@ module MainStreet
       @address = address
       @country = country
       @locale = locale
-      @searched = false
     end
 
     def success?
@@ -44,7 +43,7 @@ module MainStreet
     end
 
     def result
-      return @result if @searched
+      return @result if defined?(@result)
 
       @result = begin
         options = {lookup: lookup}
@@ -53,7 +52,6 @@ module MainStreet
         # keep mirrored with geocoder gem, including \Z
         # \Z is the same as \z when strip is used
         if @address.to_s.strip !~ /\A\d{5}(-\d{4})?\Z/
-          @searched = true
           Geocoder.search(@address, options).first
         end
       end


### PR DESCRIPTION
If `Geocoder.search().first` returns nil because there's no match, then `@result ||= begin` will call the search again repeatedly. This sets a boolean flag instead to say whether it's searched, so that the API doesn't waste calls on pointless searches.

PS I don't love the variable name `@searched` but I couldn't come up with anything better.