### PR TITLE
Pass optional language to Geocoder so we get results in that language

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ en:
         apt_missing: Apartment or suite is missing
 ```
 
+You can also request addresses in a specific language, e.g. "United States" is called "Verenigde Staten" in Dutch. Set the language to any ISO-639 language code.
+
+```ruby
+MainStreet::AddressVerifier.new(address, language: "nl")
+```
+
+As an alternative you can also set this in [Geocoder's config](https://github.com/alexreisner/geocoder/blob/master/lib/geocoder/configuration.rb).
+
 ## Data Protection
 
 We recommend encrypting street information and postal code (at the very least) for user addresses. [Lockbox](https://github.com/ankane/lockbox) is great for this. Check out [this article](https://ankane.org/sensitive-data-rails) for more details.

--- a/lib/mainstreet/address_verifier.rb
+++ b/lib/mainstreet/address_verifier.rb
@@ -1,9 +1,10 @@
 module MainStreet
   class AddressVerifier
-    def initialize(address, country: nil, locale: nil)
+    def initialize(address, country: nil, locale: nil, language: nil)
       @address = address
       @country = country
       @locale = locale
+      @language = language
     end
 
     def success?
@@ -48,6 +49,7 @@ module MainStreet
       @result = begin
         options = {lookup: MainStreet.lookup}
         options[:country] = @country if @country && !usa?
+        options[:language] = @language if @language
         # don't use smarty streets zipcode only API
         # keep mirrored with geocoder gem, including \Z
         # \Z is the same as \z when strip is used

--- a/test/address_verifier_test.rb
+++ b/test/address_verifier_test.rb
@@ -50,4 +50,12 @@ class AddressVerifierTest < Minitest::Test
     verifier = MainStreet::AddressVerifier.new(address, locale: :fr)
     assert_equal "Cette adresse n’est pas reconnue", verifier.failure_message
   end
+
+  def test_language_option
+    address = "Cologne, Germany"
+    verifier = MainStreet::AddressVerifier.new(address, language: :de)
+    assert verifier.success?
+    assert_equal "Köln", verifier.result.city
+    assert_equal "Deutschland", verifier.result.country
+  end
 end

--- a/test/cassettes/default.yml
+++ b/test/cassettes/default.yml
@@ -777,6 +777,40 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
   recorded_at: Sat, 01 Dec 2018 01:09:09 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: get
+    uri: https://nominatim.openstreetmap.org/search?accept-language=de&addressdetails=1&format=json&q=Cologne,%20Germany
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 18 Sep 2024 20:37:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '554'
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=20
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        W3sicGxhY2VfaWQiOjk5OTMxMzY3LCJsaWNlbmNlIjoiRGF0YSDCqSBPcGVuU3RyZWV0TWFwIGNvbnRyaWJ1dG9ycywgT0RiTCAxLjAuIGh0dHA6Ly9vc20ub3JnL2NvcHlyaWdodCIsIm9zbV90eXBlIjoicmVsYXRpb24iLCJvc21faWQiOjYyNTc4LCJsYXQiOiI1MC45MzgzNjEiLCJsb24iOiI2Ljk1OTk3NCIsImNsYXNzIjoiYm91bmRhcnkiLCJ0eXBlIjoiYWRtaW5pc3RyYXRpdmUiLCJwbGFjZV9yYW5rIjoxMiwiaW1wb3J0YW5jZSI6MC43NDc5MTQzNDYyNDcxMzI1LCJhZGRyZXNzdHlwZSI6ImNpdHkiLCJuYW1lIjoiS8O2bG4iLCJkaXNwbGF5X25hbWUiOiJLw7ZsbiwgTm9yZHJoZWluLVdlc3RmYWxlbiwgRGV1dHNjaGxhbmQiLCJhZGRyZXNzIjp7ImNpdHkiOiJLw7ZsbiIsInN0YXRlIjoiTm9yZHJoZWluLVdlc3RmYWxlbiIsIklTTzMxNjYtMi1sdmw0IjoiREUtTlciLCJjb3VudHJ5IjoiRGV1dHNjaGxhbmQiLCJjb3VudHJ5X2NvZGUiOiJkZSJ9LCJib3VuZGluZ2JveCI6WyI1MC44MzA0Mzk5IiwiNTEuMDg0OTc0MyIsIjYuNzcyNTMwMyIsIjcuMTYyMDI4MCJdfV0=
+  recorded_at: Wed, 18 Sep 2024 20:37:21 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
Hi Andrew,

Thanks for another great gem! 🙏

I would like to get non english results, like "Nederland", not "Netherlands", or "Deutschland" not "Germany".

GeoCoder fully supports this functionality, so why not pass it along?

We can already specify country and locale options, but country is used for searching for addresses in that country. locale is used for localizing error messages. 

So a separate language option seems appropriate.